### PR TITLE
Unify sensor setup and CLI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,18 +69,15 @@ similar to other tools such as XRootD's own ``XrdOlbMonPerf``:
    $pgio = 0;
 
 ``cms_perf`` allows to use the ``pag`` slot for one of several plugins.
-A plugin is selected by passing ``pag=<plugin name>`` to ``cms_perf``.
+A plugin is selected by passing ``--pag=<plugin formula>`` to ``cms_perf``.
 
 .. code:: bash
 
     $ # show help and plugins
     $ cms_perf --help
     ...
-    $ # show plugin specific help
-    $ python -m cms_perf pag=xrootd.num_fds -h
-    ...
     $ # use sensor with plugin
-    $ cms_perf --interval 10 pag=xrootd.num_fds --max-core-xfds 10
+    $ cms_perf --interval 10 --pag=xrd.nfds/10/ncores
     32 10 73 32 0
     33 4 72 34 0
     ...

--- a/cms_perf/__init__.py
+++ b/cms_perf/__init__.py
@@ -1,3 +1,3 @@
 """Sensor for the XRootD cms.perf directive"""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0-alpha1"

--- a/cms_perf/cli.py
+++ b/cms_perf/cli.py
@@ -1,5 +1,6 @@
 import argparse
 
+from . import cli_parser
 from . import xrd_load
 from . import net_load
 from . import __version__ as lib_version
@@ -47,16 +48,22 @@ CLI.add_argument(
     "--version", action="version", version=lib_version,
 )
 CLI.add_argument(
-    "--max-core-runq",
-    default=1,
-    help="Maximum runq/loadavg per core considered 100%%",
-    type=float,
-)
-CLI.add_argument(
     "--interval",
     default=60,
     help="Interval between output; suffixed by s (default), m, or h",
     type=duration,
+)
+CLI.add_argument(
+    "--runq", default="100.0*loadq/ncores", type=cli_parser.parse_sensor,
+)
+CLI.add_argument(
+    "--pcpu", default="pcpu", type=cli_parser.parse_sensor,
+)
+CLI.add_argument(
+    "--pmem", default="pmem", type=cli_parser.parse_sensor,
+)
+CLI.add_argument(
+    "--pio", default="pio", type=cli_parser.parse_sensor,
 )
 CLI.add_argument(
     "--sched",

--- a/cms_perf/cli.py
+++ b/cms_perf/cli.py
@@ -1,10 +1,12 @@
 import argparse
 
 from . import cli_parser
-from . import sensor  # noqa  # ensure sensors are loaded
-from . import xrd_load
-from . import net_load
 from . import __version__ as lib_version
+
+# ensure sensors are loaded
+from . import sensor  # noqa
+from . import xrd_load  # noqa
+from . import net_load  # noqa
 
 
 INTERVAL_UNITS = {"": 1, "s": 1, "m": 60, "h": 60 * 60}
@@ -64,73 +66,13 @@ CLI.add_argument(
     "--pmem", default="pmem", type=cli_parser.parse_sensor,
 )
 CLI.add_argument(
+    "--pag", default="0", type=cli_parser.parse_sensor,
+)
+CLI.add_argument(
     "--pio", default="pio", type=cli_parser.parse_sensor,
 )
 CLI.add_argument(
     "--sched",
     help="cms.sched directive to report total load and maxload on stderr",
     type=str,
-)
-CLI.set_defaults(__make_pag__=lambda args: lambda: 0)
-
-CLI_PAG = CLI.add_subparsers(
-    title="pag plugins", description="Sensor to use for the pag measurement",
-)
-
-# pag System Plugins
-CLI_PAG_NUMSOCK = CLI_PAG.add_parser(
-    "pag=num_sockets", help="Total sockets across all processes",
-)
-CLI_PAG_NUMSOCK.add_argument(
-    "--max-sockets",
-    default=1000,
-    help="Maximum total sockets considered 100%%",
-    type=int,
-)
-CLI_PAG_NUMSOCK.add_argument(
-    "--socket-kind",
-    help="Which sockets to count",
-    choices=list(net_load.ConnectionKind.__members__),
-    default="tcp",
-)
-CLI_PAG_NUMSOCK.set_defaults(
-    __make_pag__=lambda args: net_load.prepare_num_sockets(
-        net_load.ConnectionKind.__getitem__(args.socket_kind), args.max_sockets
-    )
-)
-
-# pag XRootD Plugins
-CLI_PAG_XIOWAIT = CLI_PAG.add_parser(
-    "pag=xrootd.io_wait", help="Relative time waiting for I/O by all xrootd processes",
-)
-CLI_PAG_XIOWAIT.set_defaults(
-    __make_pag__=lambda args: xrd_load.prepare_iowait(args.interval)
-)
-
-CLI_PAG_XNUMFDS = CLI_PAG.add_parser(
-    "pag=xrootd.num_fds", help="Open file handles of all xrootd processes",
-)
-CLI_PAG_XNUMFDS.add_argument(
-    "--max-core-xfds",
-    default=1,
-    help="Maximum open file handles per core considered 100%%",
-    type=float,
-)
-CLI_PAG_XNUMFDS.set_defaults(
-    __make_pag__=lambda args: xrd_load.prepare_numfds(args.interval, args.max_core_xfds)
-)
-
-CLI_PAG_XTHREADS = CLI_PAG.add_parser(
-    "pag=xrootd.num_threads", help="Threads of all xrootd processes",
-)
-CLI_PAG_XTHREADS.add_argument(
-    "--max-core-xthreads",
-    default=1,
-    help="Maximum threads per core considered 100%%",
-    type=float,
-)
-CLI_PAG_XTHREADS.set_defaults(
-    __make_pag__=lambda args: xrd_load.prepare_threads(
-        args.interval, args.max_core_xthreads
-    )
 )

--- a/cms_perf/cli.py
+++ b/cms_perf/cli.py
@@ -1,6 +1,7 @@
 import argparse
 
 from . import cli_parser
+from . import sensor  # noqa  # ensure sensors are loaded
 from . import xrd_load
 from . import net_load
 from . import __version__ as lib_version

--- a/cms_perf/cli_parser.py
+++ b/cms_perf/cli_parser.py
@@ -46,9 +46,7 @@ EXPRESSION = pp.infixNotation(
         for operators in ("* /", "+ -")
     ],
 ).setName(
-    "(NUMBER | TERM | EXPRESSION), "
-    '[ ("*" | "/" | "+" | "-"), '
-    "(NUMBER | TERM | EXPRESSION)]"
+    '(NUMBER | TERM), [ ("*" | "/" | "+" | "-"), (NUMBER | TERM | EXPRESSION)]'
 )
 
 
@@ -118,9 +116,9 @@ def _compile_parameter(parameter: inspect.Parameter):
         assert annotation in KNOWN_DOMAINS_MAP, f"unknown CLI domain {annotation}"
         domain_info = KNOWN_DOMAINS_MAP[annotation]
         return domain_info.parser.copy().setName(
-            f".{parameter.name} <: {domain_info.cli_name}"
+            f"{parameter.name}={domain_info.cli_name}"
         )
-    return EXPRESSION.copy().setName(f".{parameter.name} <: TERM")
+    return EXPRESSION.copy().setName(f"{parameter.name}=TERM")
 
 
 def _compile_cli_call(call_name: str, transpiled_name: str, call: Callable):

--- a/cms_perf/cli_parser.py
+++ b/cms_perf/cli_parser.py
@@ -16,6 +16,8 @@ import inspect
 
 import pyparsing as pp
 
+pp.ParserElement.enablePackrat()
+
 
 # Auto-generated expressions
 GENERATED = pp.Forward()
@@ -185,8 +187,9 @@ def parse_sensor(
     source: str, name: Optional[str] = None
 ) -> Callable[..., Callable[[], float]]:
     name = name if name is not None else f"<cms_perf.cli_parser code {source!r}>"
-    free_variables = ", ".join(SENSORS.keys() | TRANSFORMS.keys())
     py_source = parse(source)
+    pp.ParserElement.resetCache()  # free parser cache
+    free_variables = ", ".join(SENSORS.keys() | TRANSFORMS.keys())
     code = compile(
         f"lambda interval, {free_variables}: lambda: {py_source}",
         filename=name,

--- a/cms_perf/cli_parser.py
+++ b/cms_perf/cli_parser.py
@@ -105,7 +105,7 @@ def _cli_sensor(call: SF, cli_name: Optional[str] = None) -> SF:
     ), "sensor factories may only take regular parameters"
     cli_parameters = list(
         itertools.dropwhile(lambda param: param != "interval", raw_parameters)
-    )
+    )[1:]
     SENSORS[source_name] = SFInfo(call, cli_name, cli_parameters)
     GENERATED << pp.MatchFirst(
         (

--- a/cms_perf/cli_parser.py
+++ b/cms_perf/cli_parser.py
@@ -1,0 +1,115 @@
+from typing import TypeVar, Callable, Optional, Dict, NamedTuple, List
+from typing_extensions import Protocol
+import functools
+import inspect
+import itertools
+
+import pyparsing as pp
+
+
+# All possible expressions
+EXPRESSION = pp.Forward()
+# Auto-generated expressions
+GENERATED = pp.Forward()
+
+
+# Number literals – float should be precise enough for everything
+NUMBER = pp.Regex(r"-?\d+\.?\d*").setName("NUMBER")
+
+
+@NUMBER.setParseAction
+def transpile(result: pp.ParseResults) -> str:
+    return result[0]
+
+
+# Mathematical Operators
+def transpile_binop(result: pp.ParseResults):
+    lhs, operator, rhs = result
+    return f"({lhs} {operator} {rhs})"
+
+
+OPERATORS = pp.infixNotation(
+    EXPRESSION, [(pp.oneOf("+ * - /"), 2, pp.opAssoc.LEFT, transpile_binop)]
+)
+
+EXPRESSION <<= pp.MatchFirst((NUMBER, GENERATED, OPERATORS))
+
+
+# Sensor Plugins
+class Sensor(Protocol):
+    def __call__(self) -> float:
+        ...
+
+
+class SensorFactory(Protocol):
+    def __call__(self, interval, *args, **kwargs) -> Sensor:
+        ...
+
+
+class SFInfo(NamedTuple):
+    factory: SensorFactory
+    cli_signature: List[str]
+
+
+SF = TypeVar("SF", bound=SensorFactory)
+SENSORS: Dict[str, SFInfo] = {}
+
+
+def compile_call(call_name: str, arity: int, transpiled_name: Optional[str] = None):
+    """Compile a called with a given argument arity to a transpile expression"""
+    transpiled_name = transpiled_name if transpiled_name is not None else call_name
+    call_defaults = pp.Suppress(call_name)
+
+    @call_defaults.setParseAction
+    def transpile(result: pp.ParseResults) -> str:
+        return f"{transpiled_name}()"
+
+    if arity > 0:
+        signature = EXPRESSION
+        for _ in range(arity - 1):
+            signature = signature - pp.Suppress(",") - EXPRESSION
+        call_params = (
+            pp.Suppress(call_name) + pp.Suppress("(") - signature - pp.Suppress(")")
+        )
+
+        @call_params.setParseAction
+        def transpile(result: pp.ParseResults) -> str:
+            parameters = ", ".join(result)
+            return f"{transpiled_name}({parameters})"
+
+        return call_params, call_defaults
+    return (call_defaults,)
+
+
+def cli_sensor(call: Optional[SF] = None, *, name: Optional[str] = None):
+    """
+    Register a sensor factory for the CLI
+
+    :param call:
+    :param name:
+    :return:
+    """
+    if call is None:
+        return functools.partial(cli_sensor, name=name)
+    return _cli_sensor(call, name)
+
+
+def _cli_sensor(call: SF, name: Optional[str] = None) -> SF:
+    name = name if name is not None else call.__name__
+    assert name not in SENSORS, f"cannot re-register sensor {name}"
+    raw_parameters = inspect.signature(call).parameters
+    assert (
+        "interval" in raw_parameters
+    ), f"sensor factory {name!r} must accept an 'interval'"
+    assert all(
+        param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+        for param in raw_parameters.values()
+    ), "sensor factories may only take regular parameters"
+    cli_parameters = list(
+        itertools.dropwhile(lambda param: param != "interval", raw_parameters)
+    )
+    SENSORS[name] = SFInfo(call, cli_parameters)
+    EXPRESSION << pp.MatchFirst(
+        (*EXPRESSION.expr.exprs, *compile_call(name, len(cli_parameters)))
+    )
+    return call

--- a/cms_perf/cli_parser.py
+++ b/cms_perf/cli_parser.py
@@ -22,12 +22,16 @@ def transpile(result: pp.ParseResults) -> str:
 
 # Mathematical Operators
 def transpile_binop(result: pp.ParseResults):
-    lhs, operator, rhs = result[0]
-    return f"({lhs} {operator} {rhs})"
+    (*terms,) = result[0]
+    return f"({' '.join(terms)})"
 
 
 EXPRESSION = pp.infixNotation(
-    (NUMBER | GENERATED), [(pp.oneOf("+ * - /"), 2, pp.opAssoc.LEFT, transpile_binop)]
+    (NUMBER | GENERATED),
+    [
+        (pp.oneOf(operators), 2, pp.opAssoc.LEFT, transpile_binop)
+        for operators in ("* /", "+ -")
+    ],
 )
 
 

--- a/cms_perf/cli_parser.py
+++ b/cms_perf/cli_parser.py
@@ -45,9 +45,7 @@ EXPRESSION = pp.infixNotation(
         (pp.oneOf(operators), 2, pp.opAssoc.LEFT, transpile_binop)
         for operators in ("* /", "+ -")
     ],
-).setName(
-    '(NUMBER | TERM), [ ("*" | "/" | "+" | "-"), (NUMBER | TERM | EXPRESSION)]'
-)
+).setName('(NUMBER | TERM), [ ("*" | "/" | "+" | "-"), (NUMBER | TERM | EXPRESSION)]')
 
 
 def parse(code: str) -> str:

--- a/cms_perf/cli_parser.py
+++ b/cms_perf/cli_parser.py
@@ -1,3 +1,15 @@
+"""
+Parser to allow configuration, basic math and transformation on sensors via the CLI
+
+The syntax is loosely speaking:
+* float math including ``*``, ``/``, ``+``, ``-`` and parentheses
+* calls with and without arguments
+* constants such as enums
+and everything compiles down to Python source code.
+
+The math part is an explicitly defined.
+Both calls and constants are automatically generated from Python objects.
+"""
 from typing import TypeVar, Optional, Dict, NamedTuple, List, Callable, Tuple
 from typing_extensions import Protocol
 import inspect
@@ -35,18 +47,32 @@ EXPRESSION = pp.infixNotation(
 
 # Sensor Plugins
 class Sensor(Protocol):
+    """A sensor that can be registered for the CLI to provide values"""
+
     def __call__(self, *args, **kwargs) -> float:
         ...
 
 
-class SInfo(NamedTuple):
-    call: Sensor
+class Transform(Protocol):
+    """A callable that can be registered for the CLI to transform values"""
+
+    def __call__(self, *args: float) -> float:
+        ...
+
+
+S = TypeVar("S", bound=Sensor)
+CT = TypeVar("CT", bound=Transform)
+
+
+class CallInfo(NamedTuple):
+    call: Callable[..., float]
     cli_name: str
     cli_signature: List[str]
 
 
-S = TypeVar("S", bound=Sensor)
-SENSORS: Dict[str, SInfo] = {}  # transpiled_name => SFInfo
+# transpiled_name => CallInfo
+TRANSFORMS: Dict[str, CallInfo] = {}
+SENSORS: Dict[str, CallInfo] = {}
 
 
 def compile_call(
@@ -81,30 +107,48 @@ def compile_call(
     return (call_defaults,)
 
 
+# registration decorators
+# These are practically the same, but types differ and we may need to do
+# additional pre-processing for each in the future.
+def cli_transform(name: Optional[str] = None):
+    """
+    Register a transformation for the CLI with its own name or ``name``
+    """
+    assert not callable(name), "cli_transform must be called before decorating"
+
+    def register(call: CT) -> CT:
+        _register_cli_callable(call, name, TRANSFORMS)
+        return call
+
+    return register
+
+
 def cli_sensor(name: Optional[str] = None):
     """
     Register a sensor for the CLI with its own name or ``name``
     """
     assert not callable(name), "cli_sensor must be called before decorating"
 
-    def register(call: S):
-        _register_cli_sensor(call, name)
+    def register(call: S) -> S:
+        _register_cli_callable(call, name, SENSORS)
         return call
 
     return register
 
 
-def _register_cli_sensor(call: S, cli_name: Optional[str] = None) -> S:
+def _register_cli_callable(
+    call: S, cli_name: Optional[str], target: Dict[str, CallInfo]
+) -> S:
     cli_name = cli_name if cli_name is not None else call.__name__
     source_name = cli_name.replace(".", "_")
-    assert source_name not in SENSORS, f"cannot re-register sensor {source_name}"
+    assert source_name not in target, f"cannot re-register CLI callable {source_name}"
     raw_parameters = inspect.signature(call).parameters
     assert all(
         param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
         for param in raw_parameters.values()
-    ), "sensor factories may only take regular parameters"
+    ), "CLI callable may only take regular parameters"
     cli_parameters = [param for param in raw_parameters if param != "interval"]
-    SENSORS[source_name] = SInfo(call, cli_name, cli_parameters)
+    target[source_name] = CallInfo(call, cli_name, cli_parameters)
     GENERATED << pp.MatchFirst(
         (
             *(GENERATED.expr.exprs if GENERATED.expr else ()),
@@ -119,11 +163,12 @@ def _register_cli_sensor(call: S, cli_name: Optional[str] = None) -> S:
     return call
 
 
+# digesting of CLI information
 def prepare_sensor(
     source: str, name: Optional[str] = None
 ) -> Callable[..., Callable[[], float]]:
     name = name if name is not None else f"<cms_perf.cli_parser code {source!r}>"
-    free_variables = ", ".join(SENSORS)
+    free_variables = ", ".join(SENSORS.keys() | TRANSFORMS.keys())
     (py_source,) = EXPRESSION.parseString(source, parseAll=True)
     code = compile(
         f"lambda interval, {free_variables}: lambda: {py_source}",
@@ -137,5 +182,18 @@ def prepare_sensor(
 def compile_sensors(
     interval: float, *sensors: Callable[..., Callable[[], float]]
 ) -> List[Callable[[], float]]:
-    raw_sensors = {name: sf_info.call for name, sf_info in SENSORS.items()}
+    raw_sensors = {
+        name: sf_info.call for name, sf_info in (*SENSORS.items(), *TRANSFORMS.items())
+    }
     return [sensor(interval=interval, **raw_sensors) for sensor in sensors]
+
+
+# CLI transformations
+@cli_transform(name="max")
+def maximum(a, b):
+    return a if a >= b else b
+
+
+@cli_transform(name="min")
+def minimum(a, b):
+    return a if a <= b else b

--- a/cms_perf/cli_parser.py
+++ b/cms_perf/cli_parser.py
@@ -175,7 +175,6 @@ def prepare_sensor(
         filename=name,
         mode="eval",
     )
-    print(source, f"lambda {free_variables}: {py_source}")
     return eval(code, {}, {})
 
 

--- a/cms_perf/cli_parser.py
+++ b/cms_perf/cli_parser.py
@@ -164,7 +164,7 @@ def _register_cli_callable(
 
 
 # digesting of CLI information
-def prepare_sensor(
+def parse_sensor(
     source: str, name: Optional[str] = None
 ) -> Callable[..., Callable[[], float]]:
     name = name if name is not None else f"<cms_perf.cli_parser code {source!r}>"

--- a/cms_perf/cli_parser.py
+++ b/cms_perf/cli_parser.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Callable, Optional, Dict, NamedTuple, List
+from typing import TypeVar, Optional, Dict, NamedTuple, List
 from typing_extensions import Protocol
 import functools
 import inspect

--- a/cms_perf/cli_parser.py
+++ b/cms_perf/cli_parser.py
@@ -258,7 +258,7 @@ def compile_sensors(
     raw_sensors = {name: sf_info.call for name, sf_info in KNOWN_CALLABLES.items()}
     raw_domains = {name: dm_info.domain for name, dm_info in KNOWN_DOMAINS.items()}
     return [
-        sensor(interval=interval, **raw_sensors, **raw_domains) for sensor in sensors
+        factory(interval=interval, **raw_sensors, **raw_domains) for factory in sensors
     ]
 
 

--- a/cms_perf/cli_parser.py
+++ b/cms_perf/cli_parser.py
@@ -60,7 +60,7 @@ def compile_call(
     call_defaults = pp.Suppress(call_name)
 
     @call_defaults.setParseAction
-    def transpile(result: pp.ParseResults) -> str:
+    def transpile_no_args(result: pp.ParseResults) -> str:
         parameters = ", ".join(extra_args)
         return f"{transpiled_name}({parameters})"
 
@@ -73,7 +73,7 @@ def compile_call(
         )
 
         @call_params.setParseAction
-        def transpile(result: pp.ParseResults) -> str:
+        def transpile_with_args(result: pp.ParseResults) -> str:
             parameters = ", ".join(extra_args + tuple(result))
             return f"{transpiled_name}({parameters})"
 

--- a/cms_perf/cli_parser.py
+++ b/cms_perf/cli_parser.py
@@ -82,16 +82,20 @@ def compile_call(call_name: str, arity: int, transpiled_name: Optional[str] = No
     return (call_defaults,)
 
 
-def cli_sensor(call: Optional[SF] = None, *, name: Optional[str] = None):
+def cli_sensor(name: Optional[str] = None):
     """
     Register a sensor factory for the CLI with its own name or ``name``
     """
-    if call is None:
-        return functools.partial(cli_sensor, name=name)
-    return _cli_sensor(call, name)
+    assert not callable(name), "cli_sensor must be called before decorating"
+
+    def register(call: SF):
+        _register_cli_sensor(call, name)
+        return call
+
+    return register
 
 
-def _cli_sensor(call: SF, cli_name: Optional[str] = None) -> SF:
+def _register_cli_sensor(call: SF, cli_name: Optional[str] = None) -> SF:
     cli_name = cli_name if cli_name is not None else call.__name__
     source_name = cli_name.replace(".", "_")
     assert source_name not in SENSORS, f"cannot re-register sensor {source_name}"

--- a/cms_perf/cli_parser.py
+++ b/cms_perf/cli_parser.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Optional, Dict, NamedTuple, List
+from typing import TypeVar, Optional, Dict, NamedTuple, List, Callable
 from typing_extensions import Protocol
 import functools
 import inspect
@@ -7,8 +7,6 @@ import itertools
 import pyparsing as pp
 
 
-# All possible expressions
-EXPRESSION = pp.Forward()
 # Auto-generated expressions
 GENERATED = pp.Forward()
 
@@ -24,15 +22,13 @@ def transpile(result: pp.ParseResults) -> str:
 
 # Mathematical Operators
 def transpile_binop(result: pp.ParseResults):
-    lhs, operator, rhs = result
+    lhs, operator, rhs = result[0]
     return f"({lhs} {operator} {rhs})"
 
 
-OPERATORS = pp.infixNotation(
-    EXPRESSION, [(pp.oneOf("+ * - /"), 2, pp.opAssoc.LEFT, transpile_binop)]
+EXPRESSION = pp.infixNotation(
+    (NUMBER | GENERATED), [(pp.oneOf("+ * - /"), 2, pp.opAssoc.LEFT, transpile_binop)]
 )
-
-EXPRESSION <<= pp.MatchFirst((NUMBER, GENERATED, OPERATORS))
 
 
 # Sensor Plugins
@@ -56,7 +52,7 @@ SENSORS: Dict[str, SFInfo] = {}
 
 
 def compile_call(call_name: str, arity: int, transpiled_name: Optional[str] = None):
-    """Compile a called with a given argument arity to a transpile expression"""
+    """Compile a call with a given argument arity to a transpile expression"""
     transpiled_name = transpiled_name if transpiled_name is not None else call_name
     call_defaults = pp.Suppress(call_name)
 
@@ -83,11 +79,7 @@ def compile_call(call_name: str, arity: int, transpiled_name: Optional[str] = No
 
 def cli_sensor(call: Optional[SF] = None, *, name: Optional[str] = None):
     """
-    Register a sensor factory for the CLI
-
-    :param call:
-    :param name:
-    :return:
+    Register a sensor factory for the CLI with its own name or ``name``
     """
     if call is None:
         return functools.partial(cli_sensor, name=name)
@@ -109,7 +101,30 @@ def _cli_sensor(call: SF, name: Optional[str] = None) -> SF:
         itertools.dropwhile(lambda param: param != "interval", raw_parameters)
     )
     SENSORS[name] = SFInfo(call, cli_parameters)
-    EXPRESSION << pp.MatchFirst(
-        (*EXPRESSION.expr.exprs, *compile_call(name, len(cli_parameters)))
+    GENERATED << pp.MatchFirst(
+        (
+            *(GENERATED.expr.exprs if GENERATED.expr else ()),
+            *compile_call(name, len(cli_parameters)),
+        )
     )
     return call
+
+
+def prepare_sensor(
+    source: str, name: Optional[str] = None
+) -> Callable[..., Callable[[], float]]:
+    name = name if name is not None else f"<cms_perf.cli_parser code {source!r}>"
+    free_variables = ", ".join(SENSORS)
+    (py_source,) = EXPRESSION.parseString(source, parseAll=True)
+    code = compile(
+        f"lambda {free_variables}: lambda: {py_source}", filename=name, mode="eval"
+    )
+    print(source, f"lambda {free_variables}: {py_source}")
+    return eval(code, {}, {})
+
+
+def compile_sensors(
+    interval: float, *sensors: Callable[..., Callable[[], float]]
+) -> List[Callable[[], float]]:
+    raw_sensors = {name: sf_info.factory(interval) for name, sf_info in SENSORS.items()}
+    return [sensor(**raw_sensors) for sensor in sensors]

--- a/cms_perf/net_load.py
+++ b/cms_perf/net_load.py
@@ -5,10 +5,10 @@ import enum
 
 import psutil
 
-from .cli_parser import cli_domain
+from .cli_parser import cli_domain, cli_call
 
 
-@cli_domain("KIND")
+@cli_domain(name="KIND")
 class ConnectionKind(enum.Enum):
     inet = enum.auto()
     inet4 = enum.auto()
@@ -23,9 +23,6 @@ class ConnectionKind(enum.Enum):
     all = enum.auto()
 
 
-def prepare_num_sockets(kind: ConnectionKind, max_sockets):
-    return lambda: 100.0 * num_sockets(kind) / max_sockets
-
-
-def num_sockets(kind: ConnectionKind) -> float:
+@cli_call(name="nsockets")
+def num_sockets(kind: ConnectionKind = ConnectionKind.tcp) -> float:
     return len(psutil.net_connections(kind=kind.name))

--- a/cms_perf/net_load.py
+++ b/cms_perf/net_load.py
@@ -5,7 +5,10 @@ import enum
 
 import psutil
 
+from .cli_parser import cli_domain
 
+
+@cli_domain("KIND")
 class ConnectionKind(enum.Enum):
     inet = enum.auto()
     inet4 = enum.auto()

--- a/cms_perf/report.py
+++ b/cms_perf/report.py
@@ -68,10 +68,10 @@ def clamp_percentages(value: float) -> int:
 
 def run_forever(
     interval: float,
-    pag_sensor,
     runq: Callable[[], float],
     pmem: Callable[[], float],
     pcpu: Callable[[], float],
+    pag: Callable[[], float],
     pio: Callable[[], float],
     sched: PseudoSched = None,
 ):
@@ -80,7 +80,7 @@ def run_forever(
         runq,
         pcpu,
         pmem,
-        pag_sensor,
+        pag,
         pio,
     )
     try:
@@ -103,17 +103,21 @@ def run_forever(
 def main():
     """Run the sensor based on CLI arguments"""
     options = CLI.parse_args()
-    runq, pcpu, pmem, pio = cli_parser.compile_sensors(
-        options.interval, options.runq, options.pcpu, options.pmem, options.pio
+    runq, pcpu, pmem, pag, pio = cli_parser.compile_sensors(
+        options.interval,
+        options.runq,
+        options.pcpu,
+        options.pmem,
+        options.pag,
+        options.pio,
     )
     sched = PseudoSched.from_directive(options.sched) if options.sched else None
-    pag_sensor = options.__make_pag__(options)
     run_forever(
         interval=options.interval,
         runq=runq,
         pcpu=pcpu,
         pmem=pmem,
+        pag=pag,
         pio=pio,
-        pag_sensor=pag_sensor,
         sched=sched,
     )

--- a/cms_perf/report.py
+++ b/cms_perf/report.py
@@ -3,6 +3,7 @@ The main loop collecting and reporting values
 """
 import sys
 import time
+from functools import partial
 
 from .cli import CLI
 from .sensor import (
@@ -75,10 +76,10 @@ def run_forever(
 ):
     """Write sensor information to stdout every ``interval`` seconds"""
     base_sensors = (
-        system_load(interval),
-        cpu_utilization(interval),
-        memory_utilization(interval),
-        network_utilization(interval),
+        partial(system_load, interval),
+        partial(cpu_utilization, interval),
+        partial(memory_utilization, interval),
+        partial(network_utilization, interval),
     )
     sensors = (
         lambda: base_sensors[0]() / max_core_runq,

--- a/cms_perf/report.py
+++ b/cms_perf/report.py
@@ -4,16 +4,9 @@ The main loop collecting and reporting values
 from typing import Callable
 import sys
 import time
-from functools import partial
 
 from .cli import CLI
 from . import cli_parser
-from .sensor import (
-    system_runq,
-    cpu_utilization,
-    memory_utilization,
-    network_utilization,
-)
 
 
 class PseudoSched:

--- a/cms_perf/sensor.py
+++ b/cms_perf/sensor.py
@@ -12,22 +12,25 @@ from functools import partial
 
 import psutil
 
-Sensor = Callable[[], float]
+from .cli_parser import Sensor, cli_sensor
 
 
 # individual sensors for system state
+@cli_sensor(name='runq')
 def system_load(interval: float) -> Sensor:
     """Get the current system load sample most closely matching ``interval``"""
     loadavg_index = 0 if interval <= 60 else 1 if interval <= 300 else 2
     return lambda: 100.0 * psutil.getloadavg()[loadavg_index] / psutil.cpu_count()
 
 
+@cli_sensor(name='pcpu')
 def cpu_utilization(interval: float) -> Sensor:
     """Get the current cpu utilisation relative to ``interval``"""
     sample_interval = min(interval / 4, 1)
     return partial(psutil.cpu_percent, interval=sample_interval)
 
 
+@cli_sensor(name='pmem')
 def memory_utilization(interval: float) -> Sensor:
     """Get the current memory utilisation"""
     return lambda: psutil.virtual_memory().percent
@@ -40,6 +43,7 @@ def _get_sent_bytes():
     }
 
 
+@cli_sensor(name='pio')
 def network_utilization(interval: float) -> Sensor:
     """Get the current network utilisation relative to ``interval``"""
     sample_interval = min(interval / 4, 1)

--- a/cms_perf/sensor.py
+++ b/cms_perf/sensor.py
@@ -6,7 +6,6 @@ Sensors for the canonical cms.perf measurements
     The paging load has no canonical meaning anymore.
     It exists for backwards compatibility but is assumed 0.
 """
-from typing import Callable
 import time
 from functools import partial
 

--- a/cms_perf/sensor.py
+++ b/cms_perf/sensor.py
@@ -15,21 +15,21 @@ from .cli_parser import Sensor, cli_sensor
 
 
 # individual sensors for system state
-@cli_sensor(name='runq')
+@cli_sensor(name="runq")
 def system_load(interval: float) -> Sensor:
     """Get the current system load sample most closely matching ``interval``"""
     loadavg_index = 0 if interval <= 60 else 1 if interval <= 300 else 2
     return lambda: 100.0 * psutil.getloadavg()[loadavg_index] / psutil.cpu_count()
 
 
-@cli_sensor(name='pcpu')
+@cli_sensor(name="pcpu")
 def cpu_utilization(interval: float) -> Sensor:
     """Get the current cpu utilisation relative to ``interval``"""
     sample_interval = min(interval / 4, 1)
     return partial(psutil.cpu_percent, interval=sample_interval)
 
 
-@cli_sensor(name='pmem')
+@cli_sensor(name="pmem")
 def memory_utilization(interval: float) -> Sensor:
     """Get the current memory utilisation"""
     return lambda: psutil.virtual_memory().percent
@@ -42,7 +42,7 @@ def _get_sent_bytes():
     }
 
 
-@cli_sensor(name='pio')
+@cli_sensor(name="pio")
 def network_utilization(interval: float) -> Sensor:
     """Get the current network utilisation relative to ``interval``"""
     sample_interval = min(interval / 4, 1)

--- a/cms_perf/sensor.py
+++ b/cms_perf/sensor.py
@@ -15,7 +15,7 @@ from .cli_parser import cli_sensor
 
 # individual sensors for system state
 @cli_sensor(name="runq")
-def system_load(interval: float) -> float:
+def system_runq(interval: float) -> float:
     """Get the current system load sample most closely matching ``interval``"""
     loadavg_index = 0 if interval <= 60 else 1 if interval <= 300 else 2
     return 100.0 * psutil.getloadavg()[loadavg_index] / psutil.cpu_count()
@@ -59,3 +59,17 @@ def network_utilization(interval: float) -> float:
         for nic in interface_speed.keys() & sent_old.keys() & sent_new.keys()
     }
     return 100.0 * max(interface_utilization.values())
+
+
+# Individual sensor components
+@cli_sensor(name="loadq")
+def system_loadq(interval: float) -> float:
+    """Get the current system load sample most closely matching ``interval``"""
+    loadavg_index = 0 if interval <= 60 else 1 if interval <= 300 else 2
+    return psutil.getloadavg()[loadavg_index]
+
+
+@cli_sensor(name="ncores")
+def system_ncpu(logical=True) -> float:
+    """Get the number of CPU cores, by default including logical cores as well"""
+    return float(psutil.cpu_count(logical=logical))

--- a/cms_perf/sensor.py
+++ b/cms_perf/sensor.py
@@ -7,32 +7,31 @@ Sensors for the canonical cms.perf measurements
     It exists for backwards compatibility but is assumed 0.
 """
 import time
-from functools import partial
 
 import psutil
 
-from .cli_parser import Sensor, cli_sensor
+from .cli_parser import cli_sensor
 
 
 # individual sensors for system state
 @cli_sensor(name="runq")
-def system_load(interval: float) -> Sensor:
+def system_load(interval: float) -> float:
     """Get the current system load sample most closely matching ``interval``"""
     loadavg_index = 0 if interval <= 60 else 1 if interval <= 300 else 2
-    return lambda: 100.0 * psutil.getloadavg()[loadavg_index] / psutil.cpu_count()
+    return 100.0 * psutil.getloadavg()[loadavg_index] / psutil.cpu_count()
 
 
 @cli_sensor(name="pcpu")
-def cpu_utilization(interval: float) -> Sensor:
+def cpu_utilization(interval: float) -> float:
     """Get the current cpu utilisation relative to ``interval``"""
     sample_interval = min(interval / 4, 1)
-    return partial(psutil.cpu_percent, interval=sample_interval)
+    return psutil.cpu_percent(interval=sample_interval)
 
 
 @cli_sensor(name="pmem")
-def memory_utilization(interval: float) -> Sensor:
+def memory_utilization(interval: float) -> float:
     """Get the current memory utilisation"""
-    return lambda: psutil.virtual_memory().percent
+    return psutil.virtual_memory().percent
 
 
 def _get_sent_bytes():
@@ -43,24 +42,20 @@ def _get_sent_bytes():
 
 
 @cli_sensor(name="pio")
-def network_utilization(interval: float) -> Sensor:
+def network_utilization(interval: float) -> float:
     """Get the current network utilisation relative to ``interval``"""
     sample_interval = min(interval / 4, 1)
-
-    def sample_network_utilization() -> float:
-        interface_speed = {
-            # speed: the NIC speed expressed in mega *bits* per second
-            nic: stats.speed * 125000 * sample_interval
-            for nic, stats in psutil.net_if_stats().items()
-            if stats.isup and stats.speed > 0
-        }
-        sent_old = _get_sent_bytes()
-        time.sleep(sample_interval)
-        sent_new = _get_sent_bytes()
-        interface_utilization = {
-            nic: (sent_new[nic] - sent_old[nic]) / interface_speed[nic]
-            for nic in interface_speed.keys() & sent_old.keys() & sent_new.keys()
-        }
-        return 100.0 * max(interface_utilization.values())
-
-    return sample_network_utilization
+    interface_speed = {
+        # speed: the NIC speed expressed in mega *bits* per second
+        nic: stats.speed * 125000 * sample_interval
+        for nic, stats in psutil.net_if_stats().items()
+        if stats.isup and stats.speed > 0
+    }
+    sent_old = _get_sent_bytes()
+    time.sleep(sample_interval)
+    sent_new = _get_sent_bytes()
+    interface_utilization = {
+        nic: (sent_new[nic] - sent_old[nic]) / interface_speed[nic]
+        for nic in interface_speed.keys() & sent_old.keys() & sent_new.keys()
+    }
+    return 100.0 * max(interface_utilization.values())

--- a/cms_perf/sensor.py
+++ b/cms_perf/sensor.py
@@ -10,25 +10,25 @@ import time
 
 import psutil
 
-from .cli_parser import cli_sensor
+from .cli_parser import cli_call
 
 
 # individual sensors for system state
-@cli_sensor(name="runq")
+@cli_call(name="runq")
 def system_runq(interval: float) -> float:
     """Get the current system load sample most closely matching ``interval``"""
     loadavg_index = 0 if interval <= 60 else 1 if interval <= 300 else 2
     return 100.0 * psutil.getloadavg()[loadavg_index] / psutil.cpu_count()
 
 
-@cli_sensor(name="pcpu")
+@cli_call(name="pcpu")
 def cpu_utilization(interval: float) -> float:
     """Get the current cpu utilisation relative to ``interval``"""
     sample_interval = min(interval / 4, 1)
     return psutil.cpu_percent(interval=sample_interval)
 
 
-@cli_sensor(name="pmem")
+@cli_call(name="pmem")
 def memory_utilization(interval: float) -> float:
     """Get the current memory utilisation"""
     return psutil.virtual_memory().percent
@@ -41,7 +41,7 @@ def _get_sent_bytes():
     }
 
 
-@cli_sensor(name="pio")
+@cli_call(name="pio")
 def network_utilization(interval: float) -> float:
     """Get the current network utilisation relative to ``interval``"""
     sample_interval = min(interval / 4, 1)
@@ -62,14 +62,14 @@ def network_utilization(interval: float) -> float:
 
 
 # Individual sensor components
-@cli_sensor(name="loadq")
+@cli_call(name="loadq")
 def system_loadq(interval: float) -> float:
     """Get the current system load sample most closely matching ``interval``"""
     loadavg_index = 0 if interval <= 60 else 1 if interval <= 300 else 2
     return psutil.getloadavg()[loadavg_index]
 
 
-@cli_sensor(name="ncores")
+@cli_call(name="ncores")
 def system_ncpu(logical=True) -> float:
     """Get the number of CPU cores, by default including logical cores as well"""
     return float(psutil.cpu_count(logical=logical))

--- a/cms_perf/xrd_load.py
+++ b/cms_perf/xrd_load.py
@@ -6,28 +6,28 @@ import time
 
 import psutil
 
-from .cli_parser import cli_sensor
+from .cli_parser import cli_call
 
 
 def rescan(interval):
     return min(interval * 10, 3600)
 
 
-@cli_sensor(name="xrd.piowait")
+@cli_call(name="xrd.piowait")
 def xrd_piowait(interval: float) -> float:
     """Percentage of time waiting for IO by all XRootD processes"""
     tracker = cached_tracker(interval)
     return 100.0 * tracker.io_wait()
 
 
-@cli_sensor(name="xrd.nfds")
+@cli_call(name="xrd.nfds")
 def xrd_numfds(interval: float) -> float:
     """Number of file descriptors by all XRootD processes"""
     tracker = cached_tracker(interval)
     return tracker.num_fds()
 
 
-@cli_sensor(name="xrd.nthreads")
+@cli_call(name="xrd.nthreads")
 def xrd_threads(interval: float) -> float:
     """Number of threads by all XRootD processes"""
     tracker = cached_tracker(interval)

--- a/cms_perf/xrd_load.py
+++ b/cms_perf/xrd_load.py
@@ -76,7 +76,7 @@ class XrootdTracker:
         )
 
     def io_wait(self) -> float:
-        return max(xrd.cpu_times().iowait for xrd in self.xrootds)
+        return max((xrd.cpu_times().iowait for xrd in self.xrootds), default=0)
 
     def num_fds(self) -> int:
         return sum(xrd.num_fds() for xrd in self.xrootds)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
 ]
-requires = ["psutil >=5.6.2"]
+requires = ["psutil >=5.6.2", "pyparsing", "typing-extensions"]
 
 [tool.flit.scripts]
 cms_perf = "cms_perf.report:main"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,6 +34,8 @@ def test_run_replaced(executable: List[str]):
             "1",
             "--pmem",
             "2",
+            "--pag",
+            "3",
             "--pio",
             "4",
         ],
@@ -43,13 +45,8 @@ def test_run_replaced(executable: List[str]):
     for line in output:
         readings = line.split()
         assert len(readings) == 5
-        for reading in readings:
-            assert 0 <= int(reading) <= 100
-        assert int(readings[0]) == 0
-        assert int(readings[1]) == 1
-        assert int(readings[2]) == 2
-        assert int(readings[3]) == 0  # pag
-        assert int(readings[4]) == 4
+        for idx, reading in enumerate(readings):
+            assert idx == int(reading)
 
 
 SCHED_FIELD = tuple(enumerate(("runq", "cpu", "mem", "pag", "io")))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ EXECUTABLES = ["cms_perf"], [sys.executable, "-m", "coverage", "run", "-m", "cms
 
 @pytest.mark.parametrize("executable", EXECUTABLES)
 def test_run_normal(executable: List[str]):
-    output = capture([*executable, "--interval", "0.1"], num_lines=5)
+    output = capture([*executable, "--interval", "0.02"], num_lines=5)
     assert output
     for line in output:
         readings = line.split()
@@ -29,7 +29,7 @@ SCHED_FIELD = tuple(enumerate(("runq", "cpu", "mem", "pag", "io")))
 def test_run_sched(executable: List[str], sched_field: Tuple[int, str]):
     index, field = sched_field
     output = capture(
-        [*executable, "--interval", "0.1", "--sched", f"{field} 100"],
+        [*executable, "--interval", "0.02", "--sched", f"{field} 100"],
         num_lines=5,
         stderr=True,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,37 @@ def test_run_normal(executable: List[str]):
             assert 0 <= int(reading) <= 100
 
 
+@pytest.mark.parametrize("executable", EXECUTABLES)
+def test_run_replaced(executable: List[str]):
+    output = capture(
+        [
+            *executable,
+            "--interval",
+            "0.02",
+            "--runq",
+            "0",
+            "--pcpu",
+            "1",
+            "--pmem",
+            "2",
+            "--pio",
+            "4",
+        ],
+        num_lines=5,
+    )
+    assert output
+    for line in output:
+        readings = line.split()
+        assert len(readings) == 5
+        for reading in readings:
+            assert 0 <= int(reading) <= 100
+        assert int(readings[0]) == 0
+        assert int(readings[1]) == 1
+        assert int(readings[2]) == 2
+        assert int(readings[3]) == 0  # pag
+        assert int(readings[4]) == 4
+
+
 SCHED_FIELD = tuple(enumerate(("runq", "cpu", "mem", "pag", "io")))
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,12 +2,14 @@ from typing import List, Tuple
 import sys
 
 import pytest
+import coverage
 
 from .utility import capture
 from . import mimicry
 
-
-EXECUTABLES = ["cms_perf"], [sys.executable, "-m", "coverage", "run", "-m", "cms_perf"]
+EXECUTABLES = ["cms_perf"], [sys.executable, "-m", "cms_perf"]
+if coverage.Coverage.current() is not None:
+    EXECUTABLES += ([sys.executable, "-m", "coverage", "run", "-m", "cms_perf"],)
 
 
 @pytest.mark.parametrize("executable", EXECUTABLES)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,7 +73,7 @@ def test_run_sched(executable: List[str], sched_field: Tuple[int, str]):
         assert total == readings[index]
 
 
-PAG_PLUGINS = ["num_sockets", "xrootd.io_wait", "xrootd.num_fds", "xrootd.num_threads"]
+PAG_PLUGINS = ["xrd.piowait", "xrd.nfds", "xrd.nthreads"]
 
 
 @mimicry.skipif_unsuported
@@ -82,7 +82,7 @@ PAG_PLUGINS = ["num_sockets", "xrootd.io_wait", "xrootd.num_fds", "xrootd.num_th
 def test_run_pag_plugin(executable: List[str], pag_plugin):
     with mimicry.Process(name="xrootd", threads=20, files=20):
         output = capture(
-            [*executable, "--interval", "0.1", f"pag={pag_plugin}"], num_lines=5,
+            [*executable, "--interval", "0.1", f"--pag={pag_plugin}"], num_lines=5,
         )
         assert output
         for line in output:

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -90,6 +90,9 @@ PRIVILEGED_SENSORS = [
     "nsockets",
     "nsockets(inet6)",
     "nsockets(tcp4)",
+    "xrd.piowait",
+    "xrd.nfds",
+    "xrd.nthreads",
 ]
 
 
@@ -104,4 +107,5 @@ def test_privileged_unprivileged(source: str):
 @pytest.mark.parametrize("source", PRIVILEGED_SENSORS)
 @pytest.mark.skipif(platform.system() != "Linux", reason="Require privilege on this OS")
 def test_privileged_privileged(source: str):
-    pass
+    (sensor,) = cli_parser.compile_sensors(0.01, cli_parser.parse_sensor(source))
+    assert 0 <= sensor()

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -30,3 +30,18 @@ def test_parse(source: str):
     (sensor,) = cli_parser.compile_sensors(0.01, factory)
     assert callable(sensor)
     assert 0 <= sensor()
+
+
+KNOWN_SENSORS = [
+    (1, "1"),
+    (1.0 / 1337 / 12345, "1.0 / 1337 / 12345"),
+    (1, "fake_sensor_factory"),
+    (1, "fake.sensor"),
+]
+
+
+@pytest.mark.parametrize("expected, source", KNOWN_SENSORS)
+def test_known_sensor(expected: float, source: str):
+    factory = cli_parser.prepare_sensor(source)
+    (sensor,) = cli_parser.compile_sensors(0.01, factory)
+    assert expected == sensor()

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -25,7 +25,7 @@ SOURCES = [
 
 @pytest.mark.parametrize("source", SOURCES)
 def test_parse(source: str):
-    factory = cli_parser.prepare_sensor(source)
+    factory = cli_parser.parse_sensor(source)
     assert callable(factory)
     (sensor,) = cli_parser.compile_sensors(0.01, factory)
     assert callable(sensor)
@@ -42,7 +42,7 @@ KNOWN_SENSORS = [
 
 @pytest.mark.parametrize("expected, source", KNOWN_SENSORS)
 def test_known_sensor(expected: float, source: str):
-    factory = cli_parser.prepare_sensor(source)
+    factory = cli_parser.parse_sensor(source)
     (sensor,) = cli_parser.compile_sensors(0.01, factory)
     assert expected == sensor()
 
@@ -55,7 +55,7 @@ KNOWN_SENSOR_CALLS = [
 
 @pytest.mark.parametrize("expected, source", KNOWN_SENSOR_CALLS)
 def test_known_sensor_calls(expected: float, source: str):
-    factory = cli_parser.prepare_sensor(source)
+    factory = cli_parser.parse_sensor(source)
     (sensor,) = cli_parser.compile_sensors(0.01, factory)
     assert expected == sensor()
 
@@ -68,6 +68,6 @@ KNOWN_TRANSFORMS = [
 
 @pytest.mark.parametrize("expected, source", KNOWN_TRANSFORMS)
 def test_known_transforms(expected: float, source: str):
-    factory = cli_parser.prepare_sensor(source)
+    factory = cli_parser.parse_sensor(source)
     (sensor,) = cli_parser.compile_sensors(0.01, factory)
     assert expected == sensor()

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -1,7 +1,7 @@
 import pytest
 
 from cms_perf import cli_parser
-from cms_perf import sensor
+from cms_perf import sensor as _mounted_sensors  # noqa
 
 
 @cli_parser.cli_sensor()
@@ -49,6 +49,7 @@ def test_known_sensor(expected: float, source: str):
 
 KNOWN_SENSOR_CALLS = [
     (2, "fake_sensor_factory(2)"),
+    (6, "fake_sensor_factory(4) / fake_sensor_factory(2) * fake_sensor_factory(3)"),
 ]
 
 

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -6,20 +6,20 @@ from cms_perf import sensor
 
 @cli_parser.cli_sensor
 def fake_sensor_factory(interval: int, value=1):
-    return value
+    return lambda: value
 
 
 @cli_parser.cli_sensor(name="fake.sensor")
 def fake_aliased_sensor_factory(interval: int, value=1):
-    return value
+    return lambda: value
 
 
 SOURCES = [
     "1.0",
     "1337",
-    *cli_parser.SENSORS,
+    *(sensor.cli_name for sensor in cli_parser.SENSORS.values()),
     "1.0 / 1337",
-    *(f"{sensor} / 20" for sensor in cli_parser.SENSORS),
+    *(f"{sensor.cli_name} / 20" for sensor in cli_parser.SENSORS.values()),
 ]
 
 

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -6,12 +6,12 @@ from cms_perf import sensor
 
 @cli_parser.cli_sensor()
 def fake_sensor_factory(interval: int, value=1):
-    return lambda: value
+    return value
 
 
 @cli_parser.cli_sensor(name="fake.sensor")
 def fake_aliased_sensor_factory(interval: int, value=1):
-    return lambda: value
+    return value
 
 
 SOURCES = [

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -1,0 +1,22 @@
+import pytest
+
+from cms_perf import cli_parser
+from cms_perf import sensor
+
+
+SOURCES = [
+    "1.0",
+    "1337",
+    *cli_parser.SENSORS,
+    "1.0 / 1337",
+    *(f"{sensor} / 20" for sensor in cli_parser.SENSORS),
+]
+
+
+@pytest.mark.parametrize("source", SOURCES)
+def test_parse(source: str):
+    factory = cli_parser.prepare_sensor(source)
+    assert callable(factory)
+    (sensor,) = cli_parser.compile_sensors(0.01, factory)
+    assert callable(sensor)
+    assert 0 <= sensor()

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -5,11 +5,11 @@ import platform
 import psutil
 
 from cms_perf import cli_parser
-from cms_perf import (
+from cms_perf import (  # noqa
     sensor as _mount_sensors,
     net_load as _mount_net_load,
     xrd_load as _mount_xrd_load,
-)  # noqa
+)
 
 
 @cli_parser.cli_call()

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -64,6 +64,7 @@ def test_known_sensor_calls(expected: float, source: str):
 KNOWN_TRANSFORMS = [
     (12.3, "max(1, 12.3)"),
     (2, "max(min(2, 4), 1)"),
+    (2, "max(min(2, 4, 3), 1, 1.5)"),
 ]
 
 

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -4,6 +4,16 @@ from cms_perf import cli_parser
 from cms_perf import sensor
 
 
+@cli_parser.cli_sensor
+def fake_sensor_factory(interval: int, value=1):
+    return value
+
+
+@cli_parser.cli_sensor(name="fake.sensor")
+def fake_aliased_sensor_factory(interval: int, value=1):
+    return value
+
+
 SOURCES = [
     "1.0",
     "1337",

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -4,23 +4,26 @@ from cms_perf import cli_parser
 from cms_perf import sensor as _mounted_sensors  # noqa
 
 
-@cli_parser.cli_sensor()
+@cli_parser.cli_call()
 def fake_sensor_factory(interval: int, value=1):
     return value
 
 
-@cli_parser.cli_sensor(name="fake.sensor")
+@cli_parser.cli_call(name="fake.sensor")
 def fake_aliased_sensor_factory(interval: int, value=1):
     return value
+
+
+SENSORS = ["runq", "loadq", "pcpu", "pmem", "pio"]
 
 
 SOURCES = [
     "1.0",
     "1337",
-    *(sensor.cli_name for sensor in cli_parser.SENSORS.values()),
+    *SENSORS,
     "1.0 / 1337",
     "100.0*loadq/ncores",
-    *(f"{sensor.cli_name} / 20" for sensor in cli_parser.SENSORS.values()),
+    *(f"{sensor} / 20" for sensor in SENSORS),
 ]
 
 

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -19,6 +19,7 @@ SOURCES = [
     "1337",
     *(sensor.cli_name for sensor in cli_parser.SENSORS.values()),
     "1.0 / 1337",
+    "100.0*loadq/ncores",
     *(f"{sensor.cli_name} / 20" for sensor in cli_parser.SENSORS.values()),
 ]
 

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -58,3 +58,16 @@ def test_known_sensor_calls(expected: float, source: str):
     factory = cli_parser.prepare_sensor(source)
     (sensor,) = cli_parser.compile_sensors(0.01, factory)
     assert expected == sensor()
+
+
+KNOWN_TRANSFORMS = [
+    (12.3, "max(1, 12.3)"),
+    (2, "max(min(2, 4), 1)"),
+]
+
+
+@pytest.mark.parametrize("expected, source", KNOWN_TRANSFORMS)
+def test_known_transforms(expected: float, source: str):
+    factory = cli_parser.prepare_sensor(source)
+    (sensor,) = cli_parser.compile_sensors(0.01, factory)
+    assert expected == sensor()

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -45,3 +45,15 @@ def test_known_sensor(expected: float, source: str):
     factory = cli_parser.prepare_sensor(source)
     (sensor,) = cli_parser.compile_sensors(0.01, factory)
     assert expected == sensor()
+
+
+KNOWN_SENSOR_CALLS = [
+    (2, "fake_sensor_factory(2)"),
+]
+
+
+@pytest.mark.parametrize("expected, source", KNOWN_SENSOR_CALLS)
+def test_known_sensor_calls(expected: float, source: str):
+    factory = cli_parser.prepare_sensor(source)
+    (sensor,) = cli_parser.compile_sensors(0.01, factory)
+    assert expected == sensor()

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -4,7 +4,7 @@ from cms_perf import cli_parser
 from cms_perf import sensor
 
 
-@cli_parser.cli_sensor
+@cli_parser.cli_sensor()
 def fake_sensor_factory(interval: int, value=1):
     return lambda: value
 

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -1,19 +1,17 @@
-from functools import partial
-
 import pytest
 
 from cms_perf import sensor
 
 SENSORS = (
-    partial(sensor.system_load, 0.01),
-    partial(sensor.cpu_utilization, 0.01),
+    sensor.system_load,
+    sensor.cpu_utilization,
     sensor.memory_utilization,
-    partial(sensor.network_utilization, 0.01),
+    sensor.network_utilization,
 )
 
 
 @pytest.mark.parametrize("read_sensor", SENSORS)
 def test_sensors(read_sensor):
-    result = read_sensor()
+    result = read_sensor(interval=0.01)()
     assert type(result) is float
     assert 0.0 <= result

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -3,7 +3,7 @@ import pytest
 from cms_perf import sensor
 
 SENSORS = (
-    sensor.system_load,
+    sensor.system_runq,
     sensor.cpu_utilization,
     sensor.memory_utilization,
     sensor.network_utilization,

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -12,6 +12,6 @@ SENSORS = (
 
 @pytest.mark.parametrize("read_sensor", SENSORS)
 def test_sensors(read_sensor):
-    result = read_sensor(interval=0.01)()
+    result = read_sensor(interval=0.01)
     assert type(result) is float
     assert 0.0 <= result


### PR DESCRIPTION
This PR addresses #5. Major changes include:

* added a parser for basic math on the CLI,
* registered all current sensors for the CLI,
* removed various CLI scaling factors such as ``--max-core-runq``,
* removed various CLI special handling of ``pag`` readings.

Closes #5. Due to incompatible CLI, bumps the version number from ``0.3.X`` to ``0.4.X``..